### PR TITLE
Add Graylog GELF TCP Response Type

### DIFF
--- a/XESmartTarget.Core/Responses/GelfTcpResponse.cs
+++ b/XESmartTarget.Core/Responses/GelfTcpResponse.cs
@@ -100,6 +100,15 @@ namespace XESmartTarget.Core.Responses
                         dr.SetField("short_message", dr["message"] ?? "No message from XE session");
                     }
 
+                    // check lengths since elasticsearch has a 32kb limit
+                    foreach (DataColumn column in dr.Table.Columns)
+                    {
+                        if (dr[column.ColumnName].ToString().Length > 32766)
+                        {
+                            dr.SetField(column.ColumnName, ((string)dr[column.ColumnName]).Substring(0, 32766));
+                        }
+                    }
+
                     var rowJson = JsonConvert.SerializeObject(dr, Formatting.None, jsonSettings);
                     var byteList = new List<Byte>();
                     byteList.AddRange(Encoding.UTF8.GetBytes(rowJson));

--- a/XESmartTarget.Core/Responses/GelfTcpResponse.cs
+++ b/XESmartTarget.Core/Responses/GelfTcpResponse.cs
@@ -1,0 +1,244 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Microsoft.SqlServer.XEvent.Linq;
+using NLog;
+using System.Data;
+using XESmartTarget.Core.Utils;
+using System.Net.Sockets;
+using System.Net.Security;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
+using System.Security.Authentication;
+using System.Security.Cryptography.X509Certificates;
+
+namespace XESmartTarget.Core.Responses
+{
+    [Serializable]
+    public class GelfTcpResponse : Response
+    {
+        private static Logger logger = LogManager.GetCurrentClassLogger();
+
+        public string ServerName { get; set; }
+        public int Port { get; set; }
+        public bool Encrypt { get; set; }
+        public bool TrustServerCertificate { get; set; }
+
+        protected DataTable EventsTable = new DataTable("events");
+        private XEventDataTableAdapter xeadapter;
+        private JsonSerializerSettings jsonSettings;
+
+        public GelfTcpResponse()
+        {
+            logger.Info(String.Format("Initializing Response of Type '{0}'", this.GetType().FullName));
+
+            jsonSettings = new JsonSerializerSettings
+            {
+                NullValueHandling = NullValueHandling.Ignore,
+                Converters = { new DataRowConverter() },
+            };
+        }
+
+        public override void Process(PublishedEvent evt)
+        {
+            if (xeadapter == null)
+            {
+                xeadapter = new XEventDataTableAdapter(EventsTable);
+                xeadapter.Filter = this.Filter;
+                xeadapter.OutputColumns = new List<OutputColumn>();
+            }
+            xeadapter.ReadEvent(evt);
+
+            lock (EventsTable)
+            {
+                if (!(EventsTable.Columns.Contains("host")))
+                {
+                    EventsTable.Columns.Add("host", typeof(string));
+                }
+
+                if (!(EventsTable.Columns.Contains("version")))
+                {
+                    EventsTable.Columns.Add("version", typeof(string));
+                    EventsTable.Columns["version"].DefaultValue = "1.1";
+                }
+                
+                if (!(EventsTable.Columns.Contains("short_message")))
+                {
+                    EventsTable.Columns.Add("short_message", typeof(string));
+                }
+
+                if (!(EventsTable.Columns.Contains("timestamp")))
+                {
+                    EventsTable.Columns.Add("timestamp", typeof(double));
+                }
+
+                foreach (DataRow dr in EventsTable.Rows)
+                {
+                    // populate host column
+                    if (dr.Table.Columns.Contains("server_instance_name"))
+                    {
+                        dr.SetField("host", dr["server_instance_name"]);
+                    }
+                    else
+                    {
+                        dr.SetField("host", System.Environment.MachineName);
+                    }
+
+                    // populate the timestamp column
+                    if (dr["collection_time"] != null)
+                    {
+                        dr.SetField("timestamp", (((DateTime)dr["collection_time"]).ToUniversalTime().Subtract(new DateTime(1970, 1, 1))).TotalSeconds);
+                    } 
+                    else
+                    {
+                        dr.SetField("timestamp", DateTime.Now.ToUniversalTime().Subtract(new DateTime(1970, 1, 1)).TotalSeconds);
+                    }
+
+                    // populate short_message column
+                    if (dr["short_message"] == null)
+                    {
+                        dr.SetField("short_message", dr["message"] ?? "No message from XE session");
+                    }
+
+                    var rowJson = JsonConvert.SerializeObject(dr, Formatting.None, jsonSettings);
+                    var byteList = new List<Byte>();
+                    byteList.AddRange(Encoding.UTF8.GetBytes(rowJson));
+                    byteList.Add(0x00);
+
+                    using (TcpClient tcpClient = new TcpClient())
+                    {
+                        var connect = tcpClient.ConnectAsync(ServerName, Port);
+                        if (!(connect.Wait(500)))
+                        {
+                            logger.Error("Connection timed out");
+                            throw new Exception("Connection timed out");
+                        }
+
+                        using (NetworkStream tcpStream = tcpClient.GetStream())
+                        {
+                            if (Encrypt)
+                            {
+                                SslStream sslStream = null;
+                                if (TrustServerCertificate)
+                                {
+                                    sslStream = new SslStream(tcpStream, false, delegate { return true; }, null);
+                                }
+                                else
+                                {
+                                    sslStream = new SslStream(tcpStream, false, new RemoteCertificateValidationCallback(ValidateServerCertificate), null);
+                                }
+
+                                try
+                                {
+                                    logger.Debug("Validating certificate");
+                                    sslStream.AuthenticateAsClient(ServerName);
+                                }
+                                catch (AuthenticationException ex)
+                                {
+                                    logger.Error("Exception: {0}", ex.Message);
+                                    if (ex.InnerException != null)
+                                    {
+                                        logger.Error("Inner exception: {0}", ex.InnerException.Message);
+                                    }
+
+                                    logger.Error("Authentication failed - closing the connection.");
+                                    sslStream.Close();
+                                    tcpClient.Close();
+                                    return;
+                                }
+
+                                try
+                                {
+                                    sslStream.Write(byteList.ToArray(), 0, byteList.Count);
+                                }
+                                catch (Exception ex)
+                                {
+                                    logger.Error("Exception: {0}", ex.Message);
+                                    if (ex.InnerException != null)
+                                    {
+                                        logger.Error("Inner exception: {0}", ex.InnerException.Message);
+                                    }
+
+                                    logger.Error("Could not write bytes to stream.");
+                                    sslStream.Close();
+                                    tcpClient.Close();
+                                    return;
+                                }
+
+                                sslStream.Close();
+                            }
+                            else
+                            {
+                                try
+                                {
+                                    tcpStream.Write(byteList.ToArray(), 0, byteList.Count);
+                                }
+                                catch (Exception ex)
+                                {
+                                    logger.Error("Exception: {0}", ex.Message);
+                                    if (ex.InnerException != null)
+                                    {
+                                        logger.Error("Inner exception: {0}", ex.InnerException.Message);
+                                    }
+
+                                    logger.Error("Could not write bytes to stream.");
+                                    tcpStream.Close();
+                                    tcpClient.Close();
+                                    return;
+                                }
+                                
+                                tcpStream.Close();
+                            }
+
+                            tcpClient.Close();
+                        }
+                    }
+                }
+
+                EventsTable.Clear();
+            }
+        }
+
+        static bool ValidateServerCertificate(Object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        {
+            logger.Debug("Validating the server certificate.");
+            if (sslPolicyErrors == SslPolicyErrors.None)
+                return true;
+
+            logger.Error("Certificate error: {0}", sslPolicyErrors);
+
+            return false;
+        }
+
+        // json converter attributed to dbc on stackoverflow
+        // https://stackoverflow.com/a/33400729
+        class DataRowConverter : JsonConverter<DataRow>
+        {
+            public override DataRow ReadJson(JsonReader reader, Type objectType, DataRow existingValue, bool hasExistingValue, JsonSerializer serializer)
+            {
+                throw new NotImplementedException(string.Format("{0} is only implemented for writing.", this));
+            }
+
+            public override void WriteJson(JsonWriter writer, DataRow row, JsonSerializer serializer)
+            {
+                var table = row.Table;
+                if (table == null)
+                    throw new JsonSerializationException("no table");
+                var contractResolver = serializer.ContractResolver as DefaultContractResolver;
+
+                writer.WriteStartObject();
+                foreach (DataColumn col in row.Table.Columns)
+                {
+                    var value = row[col];
+
+                    if (serializer.NullValueHandling == NullValueHandling.Ignore && (value == null || value == DBNull.Value))
+                        continue;
+
+                    writer.WritePropertyName(contractResolver != null ? contractResolver.GetResolvedPropertyName(col.ColumnName) : col.ColumnName);
+                    serializer.Serialize(writer, value);
+                }
+                writer.WriteEndObject();
+            }
+        }
+    }
+}

--- a/XESmartTarget.Core/XESmartTarget.Core.csproj
+++ b/XESmartTarget.Core/XESmartTarget.Core.csproj
@@ -87,6 +87,9 @@
       <HintPath>..\packages\Microsoft.SqlServer.SqlManagementObjects.140.17279.0\runtimes\win-$(CurrentPlatform)\native\Microsoft.SqlServer.XEvent.Linq.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Newtonsoft.Json, Version=12.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.12.0.2\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
     <Reference Include="NLog, Version=4.0.0.0, Culture=neutral, PublicKeyToken=5120e14c03d0593c, processorArchitecture=MSIL">
       <HintPath>..\packages\NLog.4.4.12\lib\net45\NLog.dll</HintPath>
     </Reference>
@@ -125,6 +128,7 @@
     <Compile Include="Responses\AggregatedOutputColumn.cs" />
     <Compile Include="Responses\EmailResponse.cs" />
     <Compile Include="Responses\ExecuteTSQLResponse.cs" />
+    <Compile Include="Responses\GelfTcpResponse.cs" />
     <Compile Include="Responses\GroupedTableAppenderResponse.cs" />
     <Compile Include="Responses\OutputColumn.cs" />
     <Compile Include="Responses\ReplayResponse.cs" />

--- a/XESmartTarget.Core/packages.config
+++ b/XESmartTarget.Core/packages.config
@@ -5,6 +5,7 @@
   <package id="Microsoft.NETCore.Platforms" version="1.1.0" targetFramework="net452" />
   <package id="Microsoft.SqlServer.SqlManagementObjects" version="140.17283.0" targetFramework="net452" />
   <package id="NETStandard.Library" version="1.6.1" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="12.0.2" targetFramework="net452" />
   <package id="NLog" version="4.4.12" targetFramework="net452" />
   <package id="SmartFormat.Net" version="2.1.0.2" targetFramework="net452" />
   <package id="System.Collections" version="4.3.0" targetFramework="net452" />


### PR DESCRIPTION
Add a Graylog GELF TCP Response type.

### Settings
| Setting | Type | Description |
|:---|:---|:---|
| ServerName | String | Name of the Graylog server |
| Port | Integer | Port number of GELF input on Graylog server |
| Encrypt | Boolean | If set to true, the traffic will be encrypted with SSL/TLS |
| TrustServerCertificate | Boolean | If set to true, the server's certificate will not be validated |

### Response Output to Graylog
The GELF 1.1 standard requires version, host, short_message, and recommends that timestamp be set. To accommodate that the below assumptions are made.

* ```version``` is defaulted to 1.1.
* ```host``` is set to ```server_instance_name``` if it is collected by the XE session. If it's not, the server name of the collecting machine is used.
* ```short_message``` is set to ```message``` if it is collected by the XE session. If it's not, the text "No message from XE session" is sent.
* ```timestamp``` is calculated off ```collection_time```

If you have performance suggestions, please let me know. I hardly have any C# experience, so this was definitely a learning experience for me 😂. I'm currently using this to capture failed SQL queries (severity level > 10) on 14 servers. It's currently using around 20 MB of memory.
